### PR TITLE
Potential fix for code scanning alert no. 2: Replacement of a substring with itself

### DIFF
--- a/penny-k8s-frontend/vite.config.js
+++ b/penny-k8s-frontend/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
         target: "ws://localhost:8080",
         ws: true,
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ws/, "/ws"),
+        rewrite: (path) => path,
       },
     },
   },


### PR DESCRIPTION
Potential fix for [https://github.com/GavinKenna/penny-k8s/security/code-scanning/2](https://github.com/GavinKenna/penny-k8s/security/code-scanning/2)

To fix the issue, we need to either remove the redundant `replace` operation if it serves no purpose or modify it to achieve the intended functionality. Based on the context, it seems the intention might be to rewrite paths starting with `/ws` to a different prefix or structure. If no rewriting is needed, the `replace` call should be removed entirely. If rewriting is required, the replacement string should be updated to reflect the desired transformation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
